### PR TITLE
Additional split on SAMLResponse split

### DIFF
--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -75,6 +75,7 @@ func (web *Web) GetSamlLogin(conf config.SamlConfig) (string, error) {
 	wait()
 
 	saml := strings.Split(page.MustElement(`body`).MustText(), "SAMLResponse=")[1]
+	saml = strings.Split(saml, "&")[0]
 	return nurl.QueryUnescape(saml)
 
 }
@@ -95,7 +96,7 @@ func (web *Web) ClearCache() error {
 	return nil
 }
 
-//checkRodProcess gets a list running process
+// checkRodProcess gets a list running process
 // kills any hanging rod browser process from any previous improprely closed sessions
 func checkRodProcess() error {
 	pids := make([]int, 0)


### PR DESCRIPTION
---
name: Extra split to remove additional SAML Response Data
about: PR to address special case for some providers
title: ''
labels: ''
assignees: ''

---

**Describe the bug**
Some providers add additional information in the SAML Response and this appears to be randomly ordered, causing intermittent issues with validation. 
Example:
 `SAMLResponse=dHJpYnV0ZVN0YXRlbWVudD48L3NhbWw6QXNzZXJ0aW9uPjwvc2FtbHA6.........UmVzcG9uc2U+&RelayState=https://console.aws.amazon.com`
 In this case RelayState is being included and AWS to base64decode it, which is not succesful, and causes
`InvalidIdentityToken: Invalid base64 SAMLResponse (Service: AWSOpenIdDiscoveryService; Status Code: 400; Error Code: AuthSamlInvalidSamlResponseException;`

**To Reproduce**
Steps to reproduce the behavior:
1. Use the tool such as `aws-cli-auth saml -v -d 3600 -p https://foo.example.com --role arn:aws:iam::xxx:role/xxx --principal arn:aws:iam::xxx:saml-provider/xxx -s --cfg-section nonprod`
2. Log in using the correct credentials
3. Authentication completes successfully
4. See error

**Expected behavior**
User able to login with correct credentials.

**Screenshots**
n/a

**Desktop (please complete the following information):**
 - OS: Windows / Linux
 - Browser: Chrome
 - Version: all


**Additional context**
n/a
