### PR TITLE
feat: add AWS User portal support for direct role

### DIFF
--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -1,0 +1,50 @@
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tag:
 
 tagbuildrelease: tag cross-build release
 
-show_coverage:
+show_coverage: test
 	go tool cover -html=.coverage/out
 
 .PHONY: deps

--- a/README.md
+++ b/README.md
@@ -5,20 +5,38 @@
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=dnitsch_aws-cli-auth&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=dnitsch_aws-cli-auth)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dnitsch_aws-cli-auth&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dnitsch_aws-cli-auth)
 
-# aws-cli-auth
+# AWS CLI AUTH
 
+CLI tool for retrieving AWS temporary credentials using a variety of methods.
 
-CLI tool for retrieving AWS temporary credentials using SAML providers.
+**Supports**:
 
-Firstly, this package currently deals with SAML only, however if you have an OIDC IdP provider set up to AWS you can use this [package](https://github.com/openstandia/aws-cli-oidc) and likewise this [package](https://github.com/Versent/saml2aws) for standard SAML only AWS integrations - standard meaning.
+- Any IdP Provider SAML provider via WebUI
+- AWS Portal direct account => role selection
+- Role chaining for every credential exchange type
+- web_identity_token file with role chaining
+
+This tool deals with IdP logins via SAML, both into an AWS account directly or via AWS SSO Portal
+
+---
+> **NOTE**: [aws cli](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sso/login.html) now supports a login via a session into a single AWS portal, it works in a similar fashion except this tool does not store the refreshToken on the device and is meant to be used with `credential_process`
+---
+
+> If you have an OIDC IdP provider set up to AWS you can use this [aws-cli-oidc](https://github.com/openstandia/aws-cli-oidc) and likewise this [saml2aws](https://github.com/Versent/saml2aws) for standard SAML only AWS integrations - standard meaning that your IdP has a standard and flow and a supports programatic MFA submission.
 
 If, however, you need to support a non standard user journeys enforced by your IdP i.e. a sub company selection within your organization login portal, or a selection screen for different MFA providers - PingID or RSA HardToken etc.... you cannot reliably automate the flow or it would have to be too specific.
 
-As such this approach uses [go-rod](https://github.com/go-rod/rod) library to uniformly allow the user to complete any and all auth steps and selections in a managed browser session up to the point of where the SAMLResponse were to be sent to AWS ACS service `https://signin.aws.amazon.com/saml`. Capturing this via hijack request and posting to AWS STS service to exchange this for the temporary credentials.
+As such this approach uses [go-rod](https://github.com/go-rod/rod) library to uniformly allow the user to complete any and all auth steps and selections in a managed browser session up to the point of where the SAMLResponse is to be sent to AWS ACS service `https://signin.aws.amazon.com/saml`. 
+
+Capturing this via hijack request and posting to AWS STS service to exchange this for the temporary credentials.
 
 The advantage of using SAML is that real users can gain access to the AWS Console UI or programatically and audited as the same person in cloudtrail.
 
 By default the tool creates the session name - which can be audited including the persons username from the localhost.
+
+## [Installation](./docs/install.md)
+
+## [Usage](./docs/usage.md)
 
 ## Known Issues
 
@@ -29,206 +47,6 @@ By default the tool creates the session name - which can be audited including th
 - As the process of re-requesting new credentials is **by design** and should be used in places where it cannot be automated - it is good idea **IF POSSIBLE** to use longer sessions for ***NON LIVE*** AWS accounts so that the prompt is not too frequent.
 
 - Prior to `v0.8.0` you might be need to manually kill the `aws-cli-auth` process manually from your OS's process manager.
-
-## Install
-
-MacOS
-
-```bash
-curl -L https://github.com/dnitsch/aws-cli-auth/releases/latest/download/aws-cli-auth-darwin -o aws-cli-auth
-chmod +x aws-cli-auth
-sudo mv aws-cli-auth /usr/local/bin
-```
-
-Linux
-
-```bash
-curl -L https://github.com/dnitsch/aws-cli-auth/releases/latest/download/aws-cli-auth-linux -o aws-cli-auth
-chmod +x aws-cli-auth
-sudo mv aws-cli-auth /usr/local/bin
-```
-
-Windows
-
-```posh
-iwr -Uri "https://github.com/dnitsch/aws-cli-auth/releases/latest/download/aws-cli-auth-windows.exe" -OutFile "aws-cli-auth"
-```
-
-### Versioned
-
-Download a specific version from [Releases page](https://github.com/dnitsch/aws-cli-auth/releases)
-
-example for MacOS
-
-```bash
-curl -L https://github.com/dnitsch/aws-cli-auth/releases/download/v0.6.2/aws-cli-auth-darwin -o aws-cli-auth
-chmod +x aws-cli-auth
-sudo mv aws-cli-auth /usr/local/bin
-```
-
-## Usage
-
-```
-CLI tool for retrieving AWS temporary credentials using SAML providers, or specified method of retrieval - i.e. force AWS_WEB_IDENTITY.
-Useful in situations like CI jobs or containers where multiple env vars might be present.
-Stores them under the $HOME/.aws/credentials file under a specified path or returns the crednetial_process payload for use in config
-
-Usage:
-  aws-cli-auth [command]
-
-Available Commands:
-  aws-cli-auth Clears any stored credentials in the OS secret store
-  completion   Generate the autocompletion script for the specified shell
-  help         Help about any command
-  saml         Get AWS credentials and out to stdout
-  specific     Initiates a specific crednetial provider [WEB_ID]
-
-Flags:
-      --cfg-section string   config section name in the yaml config file
-  -h, --help                 help for aws-cli-auth
-  -r, --role string          Set the role you want to assume when SAML or OIDC process completes
-  -s, --store-profile        By default the credentials are returned to stdout to be used by the credential_process. Set this flag to instead store the credentials under a named profile section
-
-Use "aws-cli-auth [command] --help" for more information about a command.
-```
-
-### SAML
-
-```
-Get AWS credentials and out to stdout through your SAML provider authentication.
-
-Usage:
-  aws-cli-auth saml <SAML ProviderUrl> [flags]
-
-Flags:
-  -a, --acsurl string      Override the default ACS Url, used for checkin the post of the SAMLResponse (default "https://signin.aws.amazon.com/saml")
-  -h, --help               help for saml
-  -d, --max-duration int   Override default max session duration, in seconds, of the role session [900-43200] (default 900)
-      --principal string   Principal Arn of the SAML IdP in AWS
-  -p, --provider string    Saml Entity StartSSO Url
-
-Global Flags:
-      --cfg-section string   config section name in the yaml config file
-  -r, --role string          Set the role you want to assume when SAML or OIDC process completes
-  -s, --store-profile        By default the credentials are returned to stdout to be used by the credential_process
-```
-
-Example:
-
-```bash
-aws-cli-auth saml --cfg-section nonprod_saml_admin -p "https://your-idp.com/idp/foo?PARTNER=urn:amazon:webservices" --principal "arn:aws:iam::XXXXXXXXXX:saml-provider/IDP_ENTITY_ID" -r "arn:aws:iam::XXXXXXXXXX:role/Developer" -d 3600 -s
-```
-
-The PartnerId in most IdPs is usually `urn:amazon:webservices` - but you can change this for anything you stored it as.
-
-If successful will store the creds under the specified config section in credentials profile as per below example
-
-```ini
-[default]
-aws_access_key_id     = XXXXX
-aws_secret_access_key = YYYYYYYYY
-
-[another_profile]
-aws_access_key_id     = XXXXX
-aws_secret_access_key = YYYYYYYYY
-
-[nonprod_saml_admin]
-aws_access_key_id     = XXXXXX
-aws_secret_access_key = YYYYYYYYY
-aws_session_token     = ZZZZZZZZZZZZZZZZZZZZ
-```
-
-To give it a quick test.
-
-```bash
-aws sts get-caller-identity --profile=nonprod_saml_admin
-```
-
-### AWS SSO Portal
-
-**NOW** Includes support for AWS User Portal, largely remains the same with a few exceptions/additions:
-
-- `-r|--role`
-  needs to be in the following format `12345678901:AdministratorAccess`
-- `--sso-region`
-  region of your SSO setup
-- `--is-sso`
-  flag to set the flow over AWS SSO
-
-Sample: `aws-cli-auth saml --cfg-section test_sso_portal -p https://your_idp.com/app_id -r 12345678901:AdministratorAccess --sso-region ap-north-1 -d 3600 --is-sso --reload-before 60`
-
-### AWS Credential Process
-
-[Sourcing credentials with an external process](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) describes how to integrate aws-cli with external tool.
-You can use `aws-cli-auth` as the external process. Add the following lines to your `.aws/config` file.
-
-```
-[profile test_nonprod]
-region = eu-west-1
-credential_process=aws-cli-auth saml -p https://your-idp.com/idp/foo?PARTNER=urn:amazon:webservices --principal arn:aws:iam::XXXXXXXXXX:saml-provider/IDP_ENTITY_ID -r arn:aws:iam::XXXXXXXXXX:role/Developer -d 3600
-```
-
-Optionally you can still use it as a source profile provided your base role allows AssumeRole on that resource
-
-```
-[profile elevated_from_test_nonprod]
-role_arn = arn:aws:iam::XXXXXXXXXX:role/ElevatedRole
-source_profile = test_nonprod
-region = eu-west-1
-output = json
-```
-
-Notice the missing `-s` | `--store-profile` flag
-
-### Use in CI
-
-Often times in CI you may have multiple credential provider methods enabled for various flows - this method lets you specify the exact credential provider to use without removing environment variables.
-
-```
-Initiates a specific crednetial provider [WEB_ID] as opposed to relying on the defaultCredentialChain provider.
-This is useful in CI situations where various authentication forms maybe present from AWS_ACCESS_KEY as env vars to metadata of the node.
-Returns the same JSON object as the call to the AWS cli for any of the sts AssumeRole* commands
-
-Usage:
-  aws-cli-auth specific <flags> [flags]
-
-Flags:
-  -h, --help            help for specific
-  -m, --method string   Runs a specific credentialProvider as opposed to rel (default "WEB_ID")
-
-Global Flags:
-      --cfg-section string   config section name in the yaml config file
-  -r, --role string          Set the role you want to assume when SAML or OIDC process completes
-  -s, --store-profile        By default the credentials are returned to stdout to be used by the credential_process. Set this flag to instead store the credentials under a named profile section
-```
-
-```bash
-AWS_ROLE_ARN=arn:aws:iam::XXXX:role/some-role-in-k8s-service-account AWS_WEB_IDENTITY_TOKEN_FILE=/var/token aws-cli-auth specific | jq .
-```
-
-Above is the same as this:
-
-```bash
-AWS_ROLE_ARN=arn:aws:iam::XXXX:role/some-role-in-k8s-service-account AWS_WEB_IDENTITY_TOKEN_FILE=/var/token aws-cli-auth specific -m WEB_ID | jq .
-```
-
-### Clear
-
-```
-Clears any stored credentials in the OS secret store
-
-Usage:
-  aws-cli-auth clear-cache <flags> [flags]
-
-Flags:
-  -f, --force   If aws-cli-auth exited improprely in a previous run there is a chance that there could be hanging processes left over - this will clean them up forcefully
-  -h, --help    help for clear-cache
-
-Global Flags:
-      --cfg-section string   config section name in the yaml config file
-  -r, --role string          Set the role you want to assume when SAML or OIDC process completes
-  -s, --store-profile        By default the credentials are returned to stdout to be used by the credential_process. Set this flag to instead store the credentials under a named profile section
-```
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ To give it a quick test.
 aws sts get-caller-identity --profile=nonprod_saml_admin
 ```
 
+### AWS SSO Portal
+
+**NOW** Includes support for AWS User Portal, largely remains the same with a few exceptions/additions:
+
+- `-r|--role`
+  needs to be in the following format `12345678901:AdministratorAccess`
+- `--sso-region`
+  region of your SSO setup
+- `--is-sso`
+  flag to set the flow over AWS SSO
+
+Sample: `aws-cli-auth saml --cfg-section test_sso_portal -p https://your_idp.com/app_id -r 12345678901:AdministratorAccess --sso-region ap-north-1 -d 3600 --is-sso --reload-before 60`
+
 ### AWS Credential Process
 
 [Sourcing credentials with an external process](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) describes how to integrate aws-cli with external tool.

--- a/cmd/clear.go
+++ b/cmd/clear.go
@@ -28,7 +28,9 @@ func clear(cmd *cobra.Command, args []string) error {
 
 	web := web.New(web.NewWebConf(datadir))
 
-	secretStore, err := credentialexchange.NewSecretStore("", fmt.Sprintf("%s-%s", credentialexchange.SELF_NAME, credentialexchange.RoleKeyConverter("")), os.TempDir()+"/aws-clie-auth-lock")
+	secretStore, err := credentialexchange.NewSecretStore("",
+		fmt.Sprintf("%s-%s", credentialexchange.SELF_NAME, credentialexchange.RoleKeyConverter("")),
+		os.TempDir(), "")
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,8 @@ var (
 	cfgSectionName     string
 	storeInProfile     bool
 	killHangingProcess bool
+	role               string
+	roleChain          []string
 	verbose            bool
 	rootCmd            = &cobra.Command{
 		Use:   "aws-cli-auth",
@@ -38,6 +40,7 @@ func Execute(ctx context.Context) {
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&role, "role", "r", "", "Set the role you want to assume when SAML or OIDC process completes")
+	rootCmd.PersistentFlags().StringSliceVarP(&roleChain, "role-chain", "", []string{}, "If specified it will assume the roles from the base credentials, in order they are specified in")
 	rootCmd.PersistentFlags().StringVarP(&cfgSectionName, "cfg-section", "", "", "config section name in the yaml config file")
 	rootCmd.PersistentFlags().BoolVarP(&storeInProfile, "store-profile", "s", false, "By default the credentials are returned to stdout to be used by the credential_process. Set this flag to instead store the credentials under a named profile section")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")

--- a/cmd/saml.go
+++ b/cmd/saml.go
@@ -56,11 +56,9 @@ func init() {
 	samlCmd.PersistentFlags().StringVarP(&ssoRegion, "sso-region", "", "eu-west-1", "If using SSO, you must set the region")
 	samlCmd.PersistentFlags().IntVarP(&duration, "max-duration", "d", 900, "Override default max session duration, in seconds, of the role session [900-43200]")
 	samlCmd.PersistentFlags().BoolVarP(&isSso, "is-sso", "", false, `Enables the new AWS User portal login. 
-	If this option is specified the role specified must be in the *ACCOUNT_ID:ROLE_NAME*
-	
-	e.g.: 12345678910:PowerUser
-	
-	Do not specify the ARN of the role you want to assume.`)
+If this option is specified the role specified must be in the *ACCOUNT_ID:ROLE_NAME*
+e.g.: 12345678910:PowerUser
+Do not specify the ARN of the role you want to assume.`)
 	samlCmd.PersistentFlags().IntVarP(&reloadBeforeTime, "reload-before", "", 0, "Triggers a credentials refresh before the specified max-duration. Value provided in seconds. Should be less than the max-duration of the session")
 	rootCmd.AddCommand(samlCmd)
 }

--- a/cmd/saml.go
+++ b/cmd/saml.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path"
 	"strings"
 
@@ -25,9 +26,9 @@ var (
 	acsUrl             string
 	isSso              bool
 	ssoRegion          string
+	ssoRole            string
 	ssoUserEndpoint    string
 	ssoFedCredEndpoint string
-	role               string
 	datadir            string
 	duration           int
 	reloadBeforeTime   int
@@ -52,19 +53,22 @@ func init() {
 	samlCmd.PersistentFlags().StringVarP(&principalArn, "principal", "", "", "Principal Arn of the SAML IdP in AWS")
 	samlCmd.PersistentFlags().StringVarP(&acsUrl, "acsurl", "a", "https://signin.aws.amazon.com/saml", "Override the default ACS Url, used for checkin the post of the SAMLResponse")
 	samlCmd.PersistentFlags().StringVarP(&ssoUserEndpoint, "sso-user-endpoint", "", "https://portal.sso.%s.amazonaws.com/user", "UserEndpoint in a go style fmt.Sprintf string with a region placeholder")
+	samlCmd.PersistentFlags().StringVarP(&ssoRole, "sso-role", "", "", "Sso Role name must be in this format - 12345678910:PowerUser")
 	samlCmd.PersistentFlags().StringVarP(&ssoFedCredEndpoint, "sso-fed-endpoint", "", "https://portal.sso.%s.amazonaws.com/federation/credentials/", "FederationCredEndpoint in a go style fmt.Sprintf string with a region placeholder")
 	samlCmd.PersistentFlags().StringVarP(&ssoRegion, "sso-region", "", "eu-west-1", "If using SSO, you must set the region")
 	samlCmd.PersistentFlags().IntVarP(&duration, "max-duration", "d", 900, "Override default max session duration, in seconds, of the role session [900-43200]")
 	samlCmd.PersistentFlags().BoolVarP(&isSso, "is-sso", "", false, `Enables the new AWS User portal login. 
-If this option is specified the role specified must be in the *ACCOUNT_ID:ROLE_NAME*
-e.g.: 12345678910:PowerUser
-Do not specify the ARN of the role you want to assume.`)
+If this flag is specified the --sso-role must also be specified.`)
 	samlCmd.PersistentFlags().IntVarP(&reloadBeforeTime, "reload-before", "", 0, "Triggers a credentials refresh before the specified max-duration. Value provided in seconds. Should be less than the max-duration of the session")
 	rootCmd.AddCommand(samlCmd)
 }
 
 func getSaml(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	user, err := user.Current()
+	if err != nil {
+		return err
+	}
 
 	conf := credentialexchange.CredentialConfig{
 		ProviderUrl:  providerUrl,
@@ -73,9 +77,12 @@ func getSaml(cmd *cobra.Command, args []string) error {
 		AcsUrl:       acsUrl,
 		IsSso:        isSso,
 		SsoRegion:    ssoRegion,
+		SsoRole:      ssoRole,
 		BaseConfig: credentialexchange.BaseConfig{
 			StoreInProfile:       storeInProfile,
 			Role:                 role,
+			RoleChain:            credentialexchange.InsertRoleIntoChain(role, roleChain),
+			Username:             user.Username,
 			CfgSectionName:       cfgSectionName,
 			DoKillHangingProcess: killHangingProcess,
 			ReloadBeforeTime:     reloadBeforeTime,
@@ -83,18 +90,20 @@ func getSaml(cmd *cobra.Command, args []string) error {
 	}
 
 	if isSso {
-		ssoRole := strings.Split(role, ":")
-		if len(ssoRole) > 2 {
+		sr := strings.Split(ssoRole, ":")
+		if len(sr) > 2 {
 			return fmt.Errorf("incorrectly formatted role for AWS SSO - must only be ACCOUNT:ROLE_NAME")
 		}
 		conf.SsoUserEndpoint = fmt.Sprintf("https://portal.sso.%s.amazonaws.com/user", conf.SsoRegion)
-		conf.SsoCredFedEndpoint = fmt.Sprintf("https://portal.sso.%s.amazonaws.com/federation/credentials/", conf.SsoRegion) + fmt.Sprintf("?account_id=%s&role_name=%s&debug=true", ssoRole[0], ssoRole[1])
+		conf.SsoCredFedEndpoint = fmt.Sprintf("https://portal.sso.%s.amazonaws.com/federation/credentials/", conf.SsoRegion) + fmt.Sprintf("?account_id=%s&role_name=%s&debug=true", sr[0], sr[1])
 	}
 
 	datadir := path.Join(credentialexchange.HomeDir(), fmt.Sprintf(".%s-data", credentialexchange.SELF_NAME))
 	os.MkdirAll(datadir, 0755)
 
-	secretStore, err := credentialexchange.NewSecretStore(conf.BaseConfig.Role, fmt.Sprintf("%s-%s", credentialexchange.SELF_NAME, credentialexchange.RoleKeyConverter(conf.BaseConfig.Role)), os.TempDir()+"/aws-clie-auth-lock")
+	secretStore, err := credentialexchange.NewSecretStore(conf.BaseConfig.Role,
+		fmt.Sprintf("%s-%s", credentialexchange.SELF_NAME, credentialexchange.RoleKeyConverter(conf.BaseConfig.Role)),
+		os.TempDir(), user.Username)
 	if err != nil {
 		return err
 	}

--- a/cmd/specific.go
+++ b/cmd/specific.go
@@ -54,7 +54,7 @@ func specific(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("unsupported Method: %s", method)
 		}
 	}
-	config := credentialexchange.SamlConfig{BaseConfig: credentialexchange.BaseConfig{StoreInProfile: storeInProfile}}
+	config := credentialexchange.CredentialConfig{BaseConfig: credentialexchange.BaseConfig{StoreInProfile: storeInProfile}}
 
 	// IF role is provided it can be assumed from the WEB_ID credentials
 	//

--- a/cmd/specific.go
+++ b/cmd/specific.go
@@ -54,19 +54,20 @@ func specific(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("unsupported Method: %s", method)
 		}
 	}
-	config := credentialexchange.CredentialConfig{BaseConfig: credentialexchange.BaseConfig{StoreInProfile: storeInProfile}}
 
-	// IF role is provided it can be assumed from the WEB_ID credentials
-	//
-	if role != "" {
-		awsCreds, err = credentialexchange.AssumeRoleWithCreds(ctx, awsCreds, svc, user.Name, role)
-		if err != nil {
-			return err
-		}
+	config := credentialexchange.CredentialConfig{
+		BaseConfig: credentialexchange.BaseConfig{
+			StoreInProfile: storeInProfile,
+			Username:       user.Username,
+			Role:           role,
+			RoleChain:      credentialexchange.InsertRoleIntoChain(role, roleChain),
+		},
 	}
 
-	if err := credentialexchange.SetCredentials(awsCreds, config); err != nil {
+	awsCreds, err = credentialexchange.AssumeRoleInChain(ctx, awsCreds, svc, config.BaseConfig.Username, config.BaseConfig.RoleChain)
+	if err != nil {
 		return err
 	}
-	return nil
+
+	return credentialexchange.SetCredentials(awsCreds, config)
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,35 @@
+# Install
+
+MacOS
+
+```bash
+curl -L https://github.com/dnitsch/aws-cli-auth/releases/latest/download/aws-cli-auth-darwin -o aws-cli-auth
+chmod +x aws-cli-auth
+sudo mv aws-cli-auth /usr/local/bin
+```
+
+Linux
+
+```bash
+curl -L https://github.com/dnitsch/aws-cli-auth/releases/latest/download/aws-cli-auth-linux -o aws-cli-auth
+chmod +x aws-cli-auth
+sudo mv aws-cli-auth /usr/local/bin
+```
+
+Windows
+
+```posh
+iwr -Uri "https://github.com/dnitsch/aws-cli-auth/releases/latest/download/aws-cli-auth-windows.exe" -OutFile "aws-cli-auth"
+```
+
+## Versioned
+
+Download a specific version from [Releases page](https://github.com/dnitsch/aws-cli-auth/releases)
+
+example for MacOS
+
+```bash
+curl -L https://github.com/dnitsch/aws-cli-auth/releases/download/v0.11.0/aws-cli-auth-darwin -o aws-cli-auth
+chmod +x aws-cli-auth
+sudo mv aws-cli-auth /usr/local/bin
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,164 @@
+
+# Usage
+
+```
+CLI tool for retrieving AWS temporary credentials using SAML providers, or specified method of retrieval - i.e. force AWS_WEB_IDENTITY.
+Useful in situations like CI jobs or containers where multiple env vars might be present.
+Stores them under the $HOME/.aws/credentials file under a specified path or returns the crednetial_process payload for use in config
+
+Usage:
+  aws-cli-auth [command]
+
+Available Commands:
+  aws-cli-auth Clears any stored credentials in the OS secret store
+  completion   Generate the autocompletion script for the specified shell
+  help         Help about any command
+  saml         Get AWS credentials and out to stdout
+  specific     Initiates a specific crednetial provider [WEB_ID]
+
+Flags:
+      --cfg-section string   config section name in the yaml config file
+  -h, --help                 help for aws-cli-auth
+  -r, --role string          Set the role you want to assume when SAML or OIDC process completes
+  -s, --store-profile        By default the credentials are returned to stdout to be used by the credential_process. Set this flag to instead store the credentials under a named profile section
+
+Use "aws-cli-auth [command] --help" for more information about a command.
+```
+
+## SAML
+
+```
+Get AWS credentials and out to stdout through your SAML provider authentication.
+
+Usage:
+  aws-cli-auth saml <SAML ProviderUrl> [flags]
+
+Flags:
+  -a, --acsurl string      Override the default ACS Url, used for checkin the post of the SAMLResponse (default "https://signin.aws.amazon.com/saml")
+  -h, --help               help for saml
+  -d, --max-duration int   Override default max session duration, in seconds, of the role session [900-43200] (default 900)
+      --principal string   Principal Arn of the SAML IdP in AWS
+  -p, --provider string    Saml Entity StartSSO Url
+
+Global Flags:
+      --cfg-section string   config section name in the yaml config file
+  -r, --role string          Set the role you want to assume when SAML or OIDC process completes
+  -s, --store-profile        By default the credentials are returned to stdout to be used by the credential_process
+```
+
+Example:
+
+```bash
+aws-cli-auth saml --cfg-section nonprod_saml_admin -p "https://your-idp.com/idp/foo?PARTNER=urn:amazon:webservices" --principal "arn:aws:iam::XXXXXXXXXX:saml-provider/IDP_ENTITY_ID" -r "arn:aws:iam::XXXXXXXXXX:role/Developer" -d 3600 -s
+```
+
+The PartnerId in most IdPs is usually `urn:amazon:webservices` - but you can change this for anything you stored it as.
+
+If successful will store the creds under the specified config section in credentials profile as per below example
+
+```ini
+[default]
+aws_access_key_id     = XXXXX
+aws_secret_access_key = YYYYYYYYY
+
+[another_profile]
+aws_access_key_id     = XXXXX
+aws_secret_access_key = YYYYYYYYY
+
+[nonprod_saml_admin]
+aws_access_key_id     = XXXXXX
+aws_secret_access_key = YYYYYYYYY
+aws_session_token     = ZZZZZZZZZZZZZZZZZZZZ
+```
+
+To give it a quick test.
+
+```bash
+aws sts get-caller-identity --profile=nonprod_saml_admin
+```
+
+## AWS SSO Portal
+
+**NOW** Includes support for AWS User Portal, largely remains the same with a few exceptions/additions:
+
+- `-r|--role`
+  needs to be in the following format `12345678901:AdministratorAccess`
+- `--sso-region`
+  region of your SSO setup
+- `--is-sso`
+  flag to set the flow over AWS SSO
+
+Sample: `aws-cli-auth saml --cfg-section test_sso_portal -p https://your_idp.com/app_id -r 12345678901:AdministratorAccess --sso-region ap-north-1 -d 3600 --is-sso --reload-before 60`
+
+## AWS Credential Process
+
+[Sourcing credentials with an external process](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) describes how to integrate aws-cli with external tool.
+You can use `aws-cli-auth` as the external process. Add the following lines to your `.aws/config` file.
+
+```
+[profile test_nonprod]
+region = eu-west-1
+credential_process=aws-cli-auth saml -p https://your-idp.com/idp/foo?PARTNER=urn:amazon:webservices --principal arn:aws:iam::XXXXXXXXXX:saml-provider/IDP_ENTITY_ID -r arn:aws:iam::XXXXXXXXXX:role/Developer -d 3600
+```
+
+Optionally you can still use it as a source profile provided your base role allows AssumeRole on that resource
+
+```
+[profile elevated_from_test_nonprod]
+role_arn = arn:aws:iam::XXXXXXXXXX:role/ElevatedRole
+source_profile = test_nonprod
+region = eu-west-1
+output = json
+```
+
+Notice the missing `-s` | `--store-profile` flag
+
+## Use in CI
+
+Often times in CI you may have multiple credential provider methods enabled for various flows - this method lets you specify the exact credential provider to use without removing environment variables.
+
+```
+Initiates a specific crednetial provider [WEB_ID] as opposed to relying on the defaultCredentialChain provider.
+This is useful in CI situations where various authentication forms maybe present from AWS_ACCESS_KEY as env vars to metadata of the node.
+Returns the same JSON object as the call to the AWS cli for any of the sts AssumeRole* commands
+
+Usage:
+  aws-cli-auth specific <flags> [flags]
+
+Flags:
+  -h, --help            help for specific
+  -m, --method string   Runs a specific credentialProvider as opposed to rel (default "WEB_ID")
+
+Global Flags:
+      --cfg-section string   config section name in the yaml config file
+  -r, --role string          Set the role you want to assume when SAML or OIDC process completes
+  -s, --store-profile        By default the credentials are returned to stdout to be used by the credential_process. Set this flag to instead store the credentials under a named profile section
+```
+
+```bash
+AWS_ROLE_ARN=arn:aws:iam::XXXX:role/some-role-in-k8s-service-account AWS_WEB_IDENTITY_TOKEN_FILE=/var/token aws-cli-auth specific | jq .
+```
+
+Above is the same as this:
+
+```bash
+AWS_ROLE_ARN=arn:aws:iam::XXXX:role/some-role-in-k8s-service-account AWS_WEB_IDENTITY_TOKEN_FILE=/var/token aws-cli-auth specific -m WEB_ID | jq .
+```
+
+## Clear
+
+```
+Clears any stored credentials in the OS secret store
+
+Usage:
+  aws-cli-auth clear-cache <flags> [flags]
+
+Flags:
+  -f, --force   If aws-cli-auth exited improprely in a previous run there is a chance that there could be hanging processes left over - this will clean them up forcefully
+  -h, --help    help for clear-cache
+
+Global Flags:
+      --cfg-section string   config section name in the yaml config file
+  -r, --role string          Set the role you want to assume when SAML or OIDC process completes
+  -s, --store-profile        By default the credentials are returned to stdout to be used by the credential_process. Set this flag to instead store the credentials under a named profile section
+```

--- a/internal/cmdutils/cmdutils.go
+++ b/internal/cmdutils/cmdutils.go
@@ -22,8 +22,8 @@ type SecretStorageImpl interface {
 	SaveAWSCredential(cred *credentialexchange.AWSCredentials) error
 }
 
-// GetSamlCreds
-func GetSamlCreds(ctx context.Context, svc credentialexchange.AuthSamlApi, secretStore SecretStorageImpl, conf credentialexchange.SamlConfig, webConfig *web.WebConfig) error {
+// GetCredsWebUI
+func GetCredsWebUI(ctx context.Context, svc credentialexchange.AuthSamlApi, secretStore SecretStorageImpl, conf credentialexchange.CredentialConfig, webConfig *web.WebConfig) error {
 	if conf.BaseConfig.CfgSectionName == "" && conf.BaseConfig.StoreInProfile {
 		// Debug("Config-Section name must be provided if store-profile is enabled")
 		return fmt.Errorf("Config-Section name must be provided if store-profile is enabled %w", ErrMissingArg)
@@ -41,13 +41,27 @@ func GetSamlCreds(ctx context.Context, svc credentialexchange.AuthSamlApi, secre
 	}
 
 	if !credsValid {
-		return refreshCreds(ctx, conf, secretStore, svc, webConfig)
+		if conf.IsSso {
+			return refreshAwsSsoCreds(ctx, conf, secretStore, svc, webConfig)
+		}
+		return refreshSamlCreds(ctx, conf, secretStore, svc, webConfig)
 	}
 
 	return credentialexchange.SetCredentials(storedCreds, conf)
 }
 
-func refreshCreds(ctx context.Context, conf credentialexchange.SamlConfig, secretStore SecretStorageImpl, svc credentialexchange.AuthSamlApi, webConfig *web.WebConfig) error {
+func refreshAwsSsoCreds(ctx context.Context, conf credentialexchange.CredentialConfig, secretStore SecretStorageImpl, svc credentialexchange.AuthSamlApi, webConfig *web.WebConfig) error {
+	webBrowser := web.New(webConfig)
+	capturedCreds, err := webBrowser.GetSSOCredentials(conf)
+	if err != nil {
+		return err
+	}
+	awsCreds := &credentialexchange.AWSCredentials{}
+	awsCreds.FromRoleCredString(capturedCreds)
+	return completeCredStorage(secretStore, awsCreds, conf)
+}
+
+func refreshSamlCreds(ctx context.Context, conf credentialexchange.CredentialConfig, secretStore SecretStorageImpl, svc credentialexchange.AuthSamlApi, webConfig *web.WebConfig) error {
 
 	webBrowser := web.New(webConfig)
 
@@ -70,7 +84,10 @@ func refreshCreds(ctx context.Context, conf credentialexchange.SamlConfig, secre
 	if err != nil {
 		return err
 	}
+	return completeCredStorage(secretStore, awsCreds, conf)
+}
 
+func completeCredStorage(secretStore SecretStorageImpl, awsCreds *credentialexchange.AWSCredentials, conf credentialexchange.CredentialConfig) error {
 	awsCreds.Version = 1
 	if err := secretStore.SaveAWSCredential(awsCreds); err != nil {
 		return err

--- a/internal/cmdutils/cmdutils_test.go
+++ b/internal/cmdutils/cmdutils_test.go
@@ -134,8 +134,8 @@ func IdpHandler(t *testing.T, addAwsMock bool) http.Handler {
 	return mux
 }
 
-func testConfig() credentialexchange.SamlConfig {
-	return credentialexchange.SamlConfig{
+func testConfig() credentialexchange.CredentialConfig {
+	return credentialexchange.CredentialConfig{
 		BaseConfig: credentialexchange.BaseConfig{
 			Role:             "arn:aws:iam::1122223334:role/some-role",
 			StoreInProfile:   false,
@@ -184,7 +184,7 @@ func (s *mockSecretApi) SaveAWSCredential(cred *credentialexchange.AWSCredential
 
 func Test_GetSamlCreds_With(t *testing.T) {
 	ttests := map[string]struct {
-		config      func(t *testing.T) credentialexchange.SamlConfig
+		config      func(t *testing.T) credentialexchange.CredentialConfig
 		handler     func(t *testing.T, awsMock bool) http.Handler
 		authApi     func(t *testing.T) credentialexchange.AuthSamlApi
 		secretStore func(t *testing.T) cmdutils.SecretStorageImpl
@@ -192,7 +192,7 @@ func Test_GetSamlCreds_With(t *testing.T) {
 		errTyp      error
 	}{
 		"correct config and extracted creds but not valid anymore": {
-			config: func(t *testing.T) credentialexchange.SamlConfig {
+			config: func(t *testing.T) credentialexchange.CredentialConfig {
 				return testConfig()
 			},
 			handler: IdpHandler,
@@ -251,7 +251,7 @@ func Test_GetSamlCreds_With(t *testing.T) {
 			errTyp:    nil,
 		},
 		"correct config and extracted creds an IsValid": {
-			config: func(t *testing.T) credentialexchange.SamlConfig {
+			config: func(t *testing.T) credentialexchange.CredentialConfig {
 				conf := testConfig()
 				conf.BaseConfig.ReloadBeforeTime = 60
 				return conf
@@ -312,7 +312,7 @@ func Test_GetSamlCreds_With(t *testing.T) {
 			errTyp:    nil,
 		},
 		"mising config section name and --store-in-profile set": {
-			config: func(t *testing.T) credentialexchange.SamlConfig {
+			config: func(t *testing.T) credentialexchange.CredentialConfig {
 				tc := testConfig()
 				tc.BaseConfig.CfgSectionName = ""
 				tc.BaseConfig.StoreInProfile = true
@@ -329,7 +329,7 @@ func Test_GetSamlCreds_With(t *testing.T) {
 			errTyp:    cmdutils.ErrMissingArg,
 		},
 		"failure on unable to retrieve existing credential": {
-			config: func(t *testing.T) credentialexchange.SamlConfig {
+			config: func(t *testing.T) credentialexchange.CredentialConfig {
 				tc := testConfig()
 				tc.BaseConfig.CfgSectionName = ""
 				tc.BaseConfig.StoreInProfile = false
@@ -350,7 +350,7 @@ func Test_GetSamlCreds_With(t *testing.T) {
 			errTyp:    credentialexchange.ErrUnableToLoadAWSCred,
 		},
 		"fails on isValid": {
-			config: func(t *testing.T) credentialexchange.SamlConfig {
+			config: func(t *testing.T) credentialexchange.CredentialConfig {
 				tc := testConfig()
 				tc.BaseConfig.CfgSectionName = ""
 				tc.BaseConfig.StoreInProfile = false
@@ -398,7 +398,7 @@ func Test_GetSamlCreds_With(t *testing.T) {
 
 			ss := tt.secretStore(t)
 
-			err := cmdutils.GetSamlCreds(
+			err := cmdutils.GetCredsWebUI(
 				context.TODO(), tt.authApi(t), ss, conf,
 				web.NewWebConf(tempDir).WithHeadless().WithTimeout(10))
 

--- a/internal/credentialexchange/config.go
+++ b/internal/credentialexchange/config.go
@@ -9,6 +9,8 @@ const (
 
 type BaseConfig struct {
 	Role                 string
+	RoleChain            []string
+	Username             string
 	CfgSectionName       string
 	StoreInProfile       bool
 	DoKillHangingProcess bool
@@ -23,6 +25,7 @@ type CredentialConfig struct {
 	Duration           int
 	IsSso              bool
 	SsoRegion          string
+	SsoRole            string
 	SsoUserEndpoint    string
 	SsoCredFedEndpoint string
 }

--- a/internal/credentialexchange/config.go
+++ b/internal/credentialexchange/config.go
@@ -15,10 +15,14 @@ type BaseConfig struct {
 	ReloadBeforeTime     int
 }
 
-type SamlConfig struct {
-	BaseConfig   BaseConfig
-	ProviderUrl  string
-	PrincipalArn string
-	AcsUrl       string
-	Duration     int
+type CredentialConfig struct {
+	BaseConfig         BaseConfig
+	ProviderUrl        string
+	PrincipalArn       string
+	AcsUrl             string
+	Duration           int
+	IsSso              bool
+	SsoRegion          string
+	SsoUserEndpoint    string
+	SsoCredFedEndpoint string
 }

--- a/internal/credentialexchange/credentialexchange.go
+++ b/internal/credentialexchange/credentialexchange.go
@@ -190,13 +190,12 @@ func assumeRoleWithCreds(ctx context.Context, currentCreds *AWSCredentials, svc 
 
 // AssumeRoleInChain loops over all the roles provided
 func AssumeRoleInChain(ctx context.Context, baseCreds *AWSCredentials, svc AuthSamlApi, username string, roles []string) (*AWSCredentials, error) {
-	var awsCreds *AWSCredentials
 	for _, r := range roles {
 		c, err := assumeRoleWithCreds(ctx, baseCreds, svc, username, r)
 		if err != nil {
 			return nil, err
 		}
-		awsCreds = c
+		baseCreds = c
 	}
-	return awsCreds, nil
+	return baseCreds, nil
 }

--- a/internal/credentialexchange/credentialexchange_test.go
+++ b/internal/credentialexchange/credentialexchange_test.go
@@ -468,3 +468,53 @@ func Test_AssumeSpecifiedCreds_with(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetCredentialFromRoleCreds(t *testing.T) {
+	ttests := map[string]struct {
+		input     string
+		expect    *credentialexchange.AWSCredentials
+		expectErr bool
+		errTyp    error
+	}{
+		"succeeds with escaped format": {
+			"{\"roleCredentials\":{\"accessKeyId\":\"asdas\",\"secretAccessKey\":\"sa/08asc62pun9a\",\"sessionToken\":\"somtoken//////////YO4Dm0aJYq4K2rQ9V0B6yJMsKpkc5fo+iUT6nI99cZWmGFE\",\"expiration\":1698943755000}}",
+			&credentialexchange.AWSCredentials{
+				AWSAccessKey: "asdas",
+			},
+			false, nil,
+		},
+		"succeeds with unescaped format": {
+			`{"roleCredentials":{"accessKeyId":"asdas","secretAccessKey":"sa/08asc62pun9a","sessionToken":"somtoken//////////YO4Dm0aJYq4K2rQ9V0B6yJMsKpkc5fo+iUT6nI99cZWmGFE","expiration":1698943755000}}`,
+			&credentialexchange.AWSCredentials{
+				AWSAccessKey: "asdas",
+			},
+			false, nil,
+		},
+	}
+	for name, tt := range ttests {
+		t.Run(name, func(t *testing.T) {
+			a := &credentialexchange.AWSCredentials{}
+			got, err := a.FromRoleCredString(tt.input)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("got <nil>, wanted %s", tt.errTyp)
+				}
+				if !errors.Is(err, tt.errTyp) {
+					t.Errorf("got %s, wanted %s", err, tt.errTyp)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("got %s, wanted <nil>", err)
+			}
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.AWSAccessKey != tt.expect.AWSAccessKey {
+				t.Fatal("not matched")
+			}
+		})
+	}
+}

--- a/internal/credentialexchange/doc.go
+++ b/internal/credentialexchange/doc.go
@@ -5,5 +5,5 @@
 // Currently supports SAML as posted by an IdP to an ACS endpoint in AWS
 // AWS_WEB_IDENTITY_TOKEN_FILE and optionally can specify the exact role to choose,
 //
-//	if the TOKEN corresponds to the `chained role`.
+// if the TOKEN corresponds to the `chained role`.
 package credentialexchange

--- a/internal/credentialexchange/helper.go
+++ b/internal/credentialexchange/helper.go
@@ -61,11 +61,12 @@ func SetCredentials(creds *AWSCredentials, config CredentialConfig) error {
 }
 
 func storeCredentialsInProfile(creds AWSCredentials, configSection string) error {
-	var awsConfPath string
+	basePath := path.Join(HomeDir(), ".aws")
+	awsConfPath := path.Join(basePath, "credentials")
 
-	awsConfPath = path.Join(HomeDir(), ".aws", "credentials")
-	if _, err := os.Stat(awsConfPath); os.IsNotExist(err) {
-		os.Mkdir(awsConfPath, 0655)
+	if _, err := os.Stat(basePath); os.IsNotExist(err) {
+		os.Mkdir(basePath, 0755)
+		os.WriteFile(awsConfPath, []byte(``), 0755)
 	}
 
 	if overriddenpath, exists := os.LookupEnv("AWS_SHARED_CREDENTIALS_FILE"); exists {

--- a/internal/credentialexchange/helper.go
+++ b/internal/credentialexchange/helper.go
@@ -40,7 +40,7 @@ func SessionName(username, selfName string) string {
 	return fmt.Sprintf("%s-%s", username, selfName)
 }
 
-func SetCredentials(creds *AWSCredentials, config SamlConfig) error {
+func SetCredentials(creds *AWSCredentials, config CredentialConfig) error {
 	if config.BaseConfig.StoreInProfile {
 		if err := storeCredentialsInProfile(*creds, config.BaseConfig.CfgSectionName); err != nil {
 			return err

--- a/internal/credentialexchange/secret_test.go
+++ b/internal/credentialexchange/secret_test.go
@@ -141,7 +141,7 @@ name = "arn:aws:iam::111122342343:role/DevAdmin"
 				os.RemoveAll(tmpDir)
 			}()
 
-			crde, err := credentialexchange.NewSecretStore("roleArn", "namer", "lockDir")
+			crde, err := credentialexchange.NewSecretStore("roleArn", "namer", tmpDir, "test-user")
 			if err != nil {
 				t.Fail()
 			}
@@ -219,7 +219,7 @@ name = "arn:aws:iam::111122342343:role/DevAdmin"
 				os.RemoveAll(tmpDir)
 			}()
 
-			crde, errInit := credentialexchange.NewSecretStore("roleArn", "namer", "lockDir")
+			crde, errInit := credentialexchange.NewSecretStore("roleArn", "namer", tmpDir, "test-user")
 
 			if errInit != nil {
 				t.Fatal(errInit)
@@ -229,6 +229,88 @@ name = "arn:aws:iam::111122342343:role/DevAdmin"
 			crde.WithKeyring(tt.keyring(t)).WithLocker(tt.locker(t))
 
 			err := crde.SaveAWSCredential(tt.cred)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("got <nil>, wanted %s", tt.errTyp)
+				}
+				if !errors.Is(err, tt.errTyp) {
+					t.Errorf("got %s, wanted %s", err, tt.errTyp)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("got %s, wanted <nil>", err)
+			}
+
+		})
+	}
+}
+
+func Test_ClearAll_with(t *testing.T) {
+	ttests := map[string]struct {
+		keyring   func(t *testing.T) keyring.Keyring
+		locker    func(t *testing.T) lockgate.Locker
+		errTyp    error
+		expectErr bool
+	}{
+		"correct input": {
+			keyring: func(t *testing.T) keyring.Keyring {
+				k := &mockKeyRing{}
+				k.delete = func(service, user string) error {
+					return nil
+				}
+				return k
+			},
+			locker: func(t *testing.T) lockgate.Locker {
+				l := &mockLocker{}
+				return l
+			},
+			errTyp:    nil,
+			expectErr: false,
+		},
+		"keyring delete error": {
+			keyring: func(t *testing.T) keyring.Keyring {
+				k := &mockKeyRing{}
+				k.delete = func(service, user string) error {
+					return fmt.Errorf("someerror")
+				}
+				return k
+			},
+			locker: func(t *testing.T) lockgate.Locker {
+				l := &mockLocker{}
+				return l
+			},
+			errTyp:    nil,
+			expectErr: false,
+		},
+	}
+	for name, tt := range ttests {
+		t.Run(name, func(t *testing.T) {
+			tmpDir, _ := os.MkdirTemp(os.TempDir(), "saml-cred-test")
+			iniFile := path.Join(tmpDir, fmt.Sprintf(".%s.ini", credentialexchange.SELF_NAME))
+			os.WriteFile(iniFile, []byte(`
+[role]
+[role.someotherRole]
+name = "arn:aws:iam::111122342343:role/DevAdmin"
+`), 0777)
+			os.Setenv("HOME", tmpDir)
+			defer func() {
+				os.Clearenv()
+				os.RemoveAll(tmpDir)
+			}()
+
+			crde, errInit := credentialexchange.NewSecretStore("roleArn", "namer", tmpDir, "test-user")
+
+			if errInit != nil {
+				t.Fatal(errInit)
+				return
+			}
+
+			crde.WithKeyring(tt.keyring(t)).WithLocker(tt.locker(t))
+
+			err := crde.ClearAll()
 
 			if tt.expectErr {
 				if err == nil {

--- a/internal/credentialexchange/secret_test.go
+++ b/internal/credentialexchange/secret_test.go
@@ -282,8 +282,8 @@ func Test_ClearAll_with(t *testing.T) {
 				l := &mockLocker{}
 				return l
 			},
-			errTyp:    nil,
-			expectErr: false,
+			errTyp:    credentialexchange.ErrFailedToClearSecretStorage,
+			expectErr: true,
 		},
 	}
 	for name, tt := range ttests {

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -84,7 +84,7 @@ SAMLResponse=dsicisud99u2ubf92e9euhre&RelayState=
 func Test_WebUI_with_succesful_saml(t *testing.T) {
 	ts := httptest.NewServer(mockIdpHandler(t))
 	defer ts.Close()
-	conf := credentialexchange.SamlConfig{BaseConfig: credentialexchange.BaseConfig{}}
+	conf := credentialexchange.CredentialConfig{BaseConfig: credentialexchange.BaseConfig{}}
 	conf.AcsUrl = fmt.Sprintf("%s/saml", ts.URL)
 	conf.ProviderUrl = fmt.Sprintf("%s/idp-onload", ts.URL)
 
@@ -109,7 +109,7 @@ func Test_WebUI_with_succesful_saml(t *testing.T) {
 func Test_WebUI_timeout_and_return_error(t *testing.T) {
 	ts := httptest.NewServer(mockIdpHandler(t))
 	defer ts.Close()
-	conf := credentialexchange.SamlConfig{BaseConfig: credentialexchange.BaseConfig{}}
+	conf := credentialexchange.CredentialConfig{BaseConfig: credentialexchange.BaseConfig{}}
 	conf.AcsUrl = fmt.Sprintf("%s/saml", ts.URL)
 	conf.ProviderUrl = fmt.Sprintf("%s/idp-onload", ts.URL)
 
@@ -130,7 +130,7 @@ func Test_WebUI_timeout_and_return_error(t *testing.T) {
 func Test_ClearCache(t *testing.T) {
 	ts := httptest.NewServer(mockIdpHandler(t))
 	defer ts.Close()
-	conf := credentialexchange.SamlConfig{BaseConfig: credentialexchange.BaseConfig{}}
+	conf := credentialexchange.CredentialConfig{BaseConfig: credentialexchange.BaseConfig{}}
 	conf.AcsUrl = fmt.Sprintf("%s/unknown", ts.URL)
 	conf.ProviderUrl = fmt.Sprintf("%s/idp-onload", ts.URL)
 

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -104,8 +104,6 @@ func Test_WebUI_with_succesful_saml(t *testing.T) {
 	}
 }
 
-// 2023-10-27T09:54:59+01:00
-
 func Test_WebUI_timeout_and_return_error(t *testing.T) {
 	ts := httptest.NewServer(mockIdpHandler(t))
 	defer ts.Close()
@@ -146,4 +144,87 @@ func Test_ClearCache(t *testing.T) {
 		t.Errorf("expected <nil>, got: %s", err)
 	}
 
+}
+
+func mockSsoHandler(t *testing.T) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Server", "Server")
+		w.Header().Set("X-Amzn-Requestid", "9363fdebc232c348b71c8ba5b59f9a34")
+		w.Write([]byte(``))
+	})
+	mux.HandleFunc("/fed-endpoint", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(`{"roleCredentials":{"accessKeyId":"asdas","secretAccessKey":"sa/08asc62pun9a","sessionToken":"somtoken//////////YO4Dm0aJYq4K2rQ9V0B6yJMsKpkc5fo+iUT6nI99cZWmGFE","expiration":1698943755000}}`))
+	})
+	mux.HandleFunc("/idp-onload", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(`<!DOCTYPE html>
+		<html>
+		  <body">
+			<div id="message"></div>
+		  </body>
+		  <script type="text/javascript">
+			document.addEventListener('DOMContentLoaded', function() {
+				setTimeout(() => {window.location.href = "/user"}, 100)
+			}, false);
+		  </script>
+		</html>`))
+	})
+	return mux
+}
+
+func Test_WebUI_with_succesful_ssoLogin(t *testing.T) {
+	ts := httptest.NewServer(mockSsoHandler(t))
+	defer ts.Close()
+	conf := credentialexchange.CredentialConfig{
+		IsSso:              true,
+		SsoUserEndpoint:    fmt.Sprintf("%s/user", ts.URL),
+		SsoCredFedEndpoint: fmt.Sprintf("%s/fed-endpoint", ts.URL),
+		ProviderUrl:        fmt.Sprintf("%s/idp-onload", ts.URL),
+		AcsUrl:             fmt.Sprintf("%s/saml", ts.URL),
+		BaseConfig:         credentialexchange.BaseConfig{},
+	}
+
+	tempDir, _ := os.MkdirTemp(os.TempDir(), "web-sso-tester")
+
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	webUi := web.New(web.NewWebConf(tempDir).WithHeadless().WithTimeout(10))
+	creds, err := webUi.GetSSOCredentials(conf)
+	if err != nil {
+		t.Errorf("expected err to be <nil> got: %s", err)
+	}
+	if creds != `{"roleCredentials":{"accessKeyId":"asdas","secretAccessKey":"sa/08asc62pun9a","sessionToken":"somtoken//////////YO4Dm0aJYq4K2rQ9V0B6yJMsKpkc5fo+iUT6nI99cZWmGFE","expiration":1698943755000}}` {
+		t.Errorf("incorrect saml returned\n expected \"dsicisud99u2ubf92e9euhre\", got: %s", creds)
+	}
+}
+
+func Test_WebUI_with_timeout_ssoLogin(t *testing.T) {
+	ts := httptest.NewServer(mockSsoHandler(t))
+	defer ts.Close()
+	conf := credentialexchange.CredentialConfig{
+		IsSso:              true,
+		SsoUserEndpoint:    fmt.Sprintf("%s/user", ts.URL),
+		SsoCredFedEndpoint: fmt.Sprintf("%s/fed-endpoint", ts.URL),
+		ProviderUrl:        fmt.Sprintf("%s/idp-onload", ts.URL),
+		AcsUrl:             fmt.Sprintf("%s/saml", ts.URL),
+		BaseConfig:         credentialexchange.BaseConfig{},
+	}
+
+	tempDir, _ := os.MkdirTemp(os.TempDir(), "web-sso-tester")
+
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	webUi := web.New(web.NewWebConf(tempDir).WithHeadless().WithTimeout(0))
+	_, err := webUi.GetSSOCredentials(conf)
+
+	if !errors.Is(err, web.ErrTimedOut) {
+		t.Errorf("incorrect error returned\n expected: %s, got: %s", web.ErrTimedOut, err)
+	}
 }


### PR DESCRIPTION
fixes #9 

Enables user to specify aws account and role to get creds when an account/role is behind AWS SSO portal

New feature adds the ability to use SSO portal in the same way as current SAML binding to AWS Account

adds role chaining to all commands
