### PR TITLE
fix: remove leakless true as default

### DIFF
--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -25,6 +25,7 @@ type WebConfig struct {
 	// timeout value in seconds
 	timeout  int32
 	headless bool
+	leakless bool
 }
 
 func NewWebConf(datadir string) *WebConfig {
@@ -58,7 +59,7 @@ func New(conf *WebConfig) *Web {
 		Devtools(false).
 		Headless(conf.headless).
 		UserDataDir(conf.datadir).
-		Leakless(true)
+		Leakless(conf.leakless)
 
 	url := l.MustLaunch()
 
@@ -76,7 +77,8 @@ func New(conf *WebConfig) *Web {
 // GetSamlLogin performs a saml login for a given
 func (web *Web) GetSamlLogin(conf credentialexchange.CredentialConfig) (string, error) {
 
-	// do not clean up userdata
+	// close browser even on error
+	// should cover most cases even with leakless: false
 	defer web.browser.MustClose()
 
 	web.browser.MustPage(conf.ProviderUrl)
@@ -117,6 +119,7 @@ func (web *Web) GetSSOCredentials(conf credentialexchange.CredentialConfig) (str
 	defer web.browser.MustClose()
 
 	web.browser.MustPage(conf.ProviderUrl)
+
 	router := web.browser.HijackRequests()
 	defer router.MustStop()
 


### PR DESCRIPTION
---
name: Bug report
about: Create a report to help us improve
title: 'leakless on windows causes an error when antivirus is enabled'
labels: ''
assignees: ''

---

**Describe the bug**
A clear and concise description of what the bug is.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

**Expected behavior**
A clear and concise description of what you expected to happen.

**Screenshots**
If applicable, add screenshots to help explain your problem.

**Desktop (please complete the following information):**
 - OS: [e.g. iOS]
 - Browser [e.g. chrome, safari]
 - Version [e.g. 22]

**Smartphone (please complete the following information):**
 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]

**Additional context**
Add any other context about the problem here.
